### PR TITLE
Fix success counter bug

### DIFF
--- a/motd_stress_test_optimized.py
+++ b/motd_stress_test_optimized.py
@@ -403,10 +403,6 @@ def main():
                     logger.error(f"查询失败：{e}")
                     with stats_lock:
                         stats["failure"] += 1
-                else:
-                    # 成功：只写日志文件，不打印到控制台
-                    with stats_lock:
-                        stats["success"] += 1
                 completed += 1
                 draw_progress("收集中", completed, total)
 


### PR DESCRIPTION
## Summary
- fix duplicate increment of success counter in progress loop

## Testing
- `python3 -m py_compile motd_stress_test_optimized.py`
- `python3 motd_stress_test_optimized.py --help | head -n 5` *(fails: ModuleNotFoundError: No module named 'mcstatus')*

------
https://chatgpt.com/codex/tasks/task_e_6842a4f2b7c4833186f7e4f905419c71